### PR TITLE
Hw 5

### DIFF
--- a/lesson-5/structures/cache/lru.go
+++ b/lesson-5/structures/cache/lru.go
@@ -1,0 +1,93 @@
+package cache
+
+import (
+	"container/list"
+	"errors"
+)
+
+var (
+	ErrNotExists   = errors.New("Key does not exists in cache")
+	ErrInvalidSize = errors.New("Cache size cannot be 0 or negative")
+)
+
+type cacheItem struct {
+	key   string
+	value interface{}
+}
+
+type LRUCache struct {
+	size  int
+	queue *list.List
+	items map[string]*list.Element
+}
+
+// Get returns cached value via key.
+// If key does not exists returns ErrNotExists
+func (lru *LRUCache) Get(key string) (value interface{}, err error) {
+	item, ok := lru.items[key]
+
+	if !ok {
+		return nil, ErrNotExists
+	}
+
+	lru.queue.MoveToFront(item)
+	value = item.Value.(cacheItem).value
+	return value, nil
+}
+
+// Set store key-value pair.
+// If size of cache exceed max length, older key will be dropped.
+func (lru *LRUCache) Set(key string, value interface{}) {
+	item, ok := lru.items[key]
+	if ok {
+		// key exists => update value and move key to top in queue
+		lru.queue.MoveToFront(item)
+		item.Value = cacheItem{key, value}
+		return
+	}
+
+	if lru.queue.Len() == lru.size {
+		// key does not exists, we should add the new one.
+		// but max size exceeded => remove less used
+		itemToRemove := lru.queue.Remove(lru.queue.Back()).(cacheItem)
+		delete(lru.items, itemToRemove.key)
+	}
+
+	newItem := lru.queue.PushFront(cacheItem{key, value})
+	lru.items[key] = newItem
+}
+
+// Delete removes key-value pair from cache.
+func (lru *LRUCache) Delete(key string) (err error) {
+	item, ok := lru.items[key]
+	if !ok {
+		return ErrNotExists
+	}
+
+	lru.queue.Remove(item)
+	delete(lru.items, key)
+	return nil
+}
+
+// Keys return list of stored keys in order
+// from least to most recetly used. O(N) comlexity
+func (lru *LRUCache) Keys() (keys []string) {
+	keys = make([]string, lru.queue.Len())
+	item := lru.queue.Front()
+	for i := 0; i < lru.queue.Len(); i++ {
+		keys[i] = item.Value.(cacheItem).key
+		item = item.Next()
+	}
+	return keys
+}
+
+// NewLRUCache creates new LRU instance with provided max size
+func NewLRUCache(size int) (cache *LRUCache, err error) {
+	if size <= 0 {
+		return nil, ErrInvalidSize
+	}
+
+	values := make(map[string]*list.Element, size)
+	queue := list.New()
+	return &LRUCache{size, queue, values}, nil
+}

--- a/lesson-5/structures/cache/lru_test.go
+++ b/lesson-5/structures/cache/lru_test.go
@@ -1,0 +1,168 @@
+package cache
+
+import "testing"
+
+var (
+	testLRUData map[string]int = map[string]int{
+		"one":   1,
+		"two":   2,
+		"three": 3,
+		"four":  4,
+	}
+	testCacheSize = 3
+)
+
+func TestLRUCache(t *testing.T) {
+	cache, err := NewLRUCache(testCacheSize)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	t.Run("fill cache", func(t *testing.T) {
+		testKeys := []string{"one", "two", "three"}
+		expectedKeys := []string{"three", "two", "one"}
+
+		for _, key := range testKeys {
+			cache.Set(key, testLRUData[key])
+		}
+
+		gotKeys := cache.Keys()
+
+		if len(gotKeys) != len(expectedKeys) {
+			t.Errorf("too may keys, got %d, expected %d", len(gotKeys), len(expectedKeys))
+		}
+
+		for i := range gotKeys {
+			if gotKeys[i] != expectedKeys[i] {
+				t.Errorf("invalid keys order, got %s, expected %s", gotKeys[i], expectedKeys[i])
+			}
+		}
+	})
+
+	t.Run("get key", func(t *testing.T) {
+		testKey := "one"
+		expectedValue := testLRUData[testKey]
+		// get operation should hit key
+		expectedKeys := []string{"one", "three", "two"}
+
+		value, err := cache.Get(testKey)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if value != expectedValue {
+			t.Errorf("invalid value got %d, expected %d", value, expectedValue)
+		}
+
+		gotKeys := cache.Keys()
+
+		if len(gotKeys) != len(expectedKeys) {
+			t.Errorf("too may keys, got %d, expected %d", len(gotKeys), len(expectedKeys))
+		}
+
+		for i := range gotKeys {
+			if gotKeys[i] != expectedKeys[i] {
+				t.Errorf("invalid keys order, got %s, expected %s", gotKeys[i], expectedKeys[i])
+			}
+		}
+	})
+
+	t.Run("update key", func(t *testing.T) {
+		testKey := "two"
+		testValue := 20
+		// update operation should hit key
+		expectedKeys := []string{"two", "one", "three"}
+
+		cache.Set(testKey, testValue)
+		updValue, err := cache.Get(testKey)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if updValue != testValue {
+			t.Errorf("invalid value got %d, expected %d", updValue, testValue)
+		}
+
+		gotKeys := cache.Keys()
+
+		if len(gotKeys) != len(expectedKeys) {
+			t.Errorf("too may keys, got %d, expected %d", len(gotKeys), len(expectedKeys))
+		}
+
+		for i := range gotKeys {
+			if gotKeys[i] != expectedKeys[i] {
+				t.Errorf("invalid keys order, got %s, expected %s", gotKeys[i], expectedKeys[i])
+			}
+		}
+	})
+
+	t.Run("add extra key", func(t *testing.T) {
+		testKey := "four"
+		testValue := testLRUData[testKey]
+		// add extra key should drop the older one
+		expectedKeys := []string{"four", "two", "one"}
+		olderKey := "three"
+
+		cache.Set(testKey, testValue)
+		value, err := cache.Get(testKey)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if value != testValue {
+			t.Errorf("invalid value got %d, expected %d", value, testValue)
+		}
+
+		// older value should not exists
+		_, err = cache.Get(olderKey)
+		if err != ErrNotExists {
+			t.Fatalf("unexpected error: got %v, expected %v", err, ErrNotExists)
+		}
+
+		gotKeys := cache.Keys()
+
+		if len(gotKeys) != len(expectedKeys) {
+			t.Errorf("too may keys, got %d, expected %d", len(gotKeys), len(expectedKeys))
+		}
+
+		for i := range gotKeys {
+			if gotKeys[i] != expectedKeys[i] {
+				t.Errorf("invalid keys order, got %s, expected %s", gotKeys[i], expectedKeys[i])
+			}
+		}
+	})
+
+	t.Run("delete key", func(t *testing.T) {
+		testKey := "four"
+		expectedKeys := []string{"two", "one"}
+
+		err := cache.Delete(testKey)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// deleted value should not exists
+		_, err = cache.Get(testKey)
+		if err != ErrNotExists {
+			t.Fatalf("unexpected error: got %v, expected %v", err, ErrNotExists)
+		}
+
+		gotKeys := cache.Keys()
+
+		if len(gotKeys) != len(expectedKeys) {
+			t.Errorf("too may keys, got %d, expected %d", len(gotKeys), len(expectedKeys))
+		}
+
+		for i := range gotKeys {
+			if gotKeys[i] != expectedKeys[i] {
+				t.Errorf("invalid keys order, got %s, expected %s", gotKeys[i], expectedKeys[i])
+			}
+		}
+	})
+
+	t.Run("delete not existing key", func(t *testing.T) {
+		testKey := "notexistsing"
+
+		err := cache.Delete(testKey)
+		if err != ErrNotExists {
+			t.Fatalf("unexpected error: got %v, expected %v", err, ErrNotExists)
+		}
+	})
+}

--- a/lesson-5/structures/list/double_list.go
+++ b/lesson-5/structures/list/double_list.go
@@ -1,0 +1,190 @@
+package list
+
+import "errors"
+
+var ErrNotExists = errors.New("Element of list does not exists")
+
+// DoubleListNode is element of list
+type DoubleListNode struct {
+	Value interface{}
+	next  *DoubleListNode
+	prev  *DoubleListNode
+	list  *DoubleLinkedList
+}
+
+// Next iterates from node till head of list.
+// Returns nil when head has been riched
+func (n *DoubleListNode) Next() *DoubleListNode {
+	return n.next
+}
+
+// Prev iterates from node till tail of list.
+// Returns nil when tail has been riched
+func (n *DoubleListNode) Prev() *DoubleListNode {
+	return n.prev
+}
+
+// DoubleLinkedList provides methods for working with double linked list
+type DoubleLinkedList struct {
+	len  int
+	head *DoubleListNode
+	tail *DoubleListNode
+}
+
+// linkNodes connects two nodes to each other and to list instance
+func (l *DoubleLinkedList) linkNodes(prevNode, nextNode *DoubleListNode) {
+	if prevNode != nil {
+		prevNode.next = nextNode
+		prevNode.list = l
+	}
+	if nextNode != nil {
+		nextNode.prev = prevNode
+		nextNode.list = l
+	}
+}
+
+// linkNodes disconnects two nodes from each other and from list instance
+func (l *DoubleLinkedList) unlinkNodes(prevNode, nextNode *DoubleListNode) {
+	if prevNode != nil {
+		prevNode.next = nil
+		prevNode.list = nil
+	}
+	if nextNode != nil {
+		nextNode.prev = nil
+		nextNode.list = nil
+	}
+}
+
+// Head returns first element of list
+func (l *DoubleLinkedList) Head() *DoubleListNode {
+	return l.head
+}
+
+// Tail returns last element of list
+func (l *DoubleLinkedList) Tail() *DoubleListNode {
+	return l.tail
+}
+
+// Len returns elements count
+func (l *DoubleLinkedList) Len() int {
+	return l.len
+}
+
+// PushHead appends new element in front of list
+func (l *DoubleLinkedList) PushHead(item *DoubleListNode) {
+	if item == nil {
+		return
+	}
+
+	l.len++
+	l.linkNodes(l.head, item)
+
+	l.head = item
+	// tail == nil means than first item pushed =>
+	// tail should point to that item too
+	if l.tail == nil {
+		l.tail = item
+	}
+}
+
+// PushTail appends new element in back of list
+func (l *DoubleLinkedList) PushTail(item *DoubleListNode) {
+	if item == nil {
+		return
+	}
+
+	l.len++
+	l.linkNodes(item, l.tail)
+
+	l.tail = item
+	// head == nil means than first item pushed =>
+	// head should point to that item too
+	if l.head == nil {
+		l.head = item
+	}
+}
+
+// PopHead disconnects element from front of list and returns it
+func (l *DoubleLinkedList) PopHead() *DoubleListNode {
+	// empty list
+	if l.head == nil {
+		return nil
+	}
+
+	l.len--
+	result := l.head
+	l.head = l.head.prev
+
+	// means we have removed last item =>
+	// tail should be nil too
+	if l.head == nil {
+		l.tail = nil
+	}
+
+	l.unlinkNodes(l.head, result)
+	return result
+}
+
+// PopTail disconnects element from front of list and returns it
+func (l *DoubleLinkedList) PopTail() *DoubleListNode {
+	// empty list
+	if l.tail == nil {
+		return nil
+	}
+
+	l.len--
+	result := l.tail
+	l.tail = l.tail.next
+
+	// means we have removed last item =>
+	// head should be nil too
+	if l.tail == nil {
+		l.head = nil
+	}
+
+	l.unlinkNodes(result, l.head)
+	return result
+}
+
+// InsertBefore appends newItem before item.
+// item should be pointer to element of current list instance.
+func (l *DoubleLinkedList) InsertBefore(item, newItem *DoubleListNode) error {
+	if item == nil || item.list != l {
+		return ErrNotExists
+	}
+
+	l.len++
+	l.linkNodes(item.prev, newItem)
+	l.linkNodes(newItem, item)
+
+	return nil
+}
+
+// InsertAfter appends newItem after item.
+// item should be pointer to element of current list instance.
+func (l *DoubleLinkedList) InsertAfter(item, newItem *DoubleListNode) error {
+	if item == nil || item.list != l {
+		return ErrNotExists
+	}
+
+	l.len++
+	l.linkNodes(newItem, item.next)
+	l.linkNodes(item, newItem)
+
+	return nil
+}
+
+// Remove element from list
+// item should be pointer to element of current list instance.
+func (l *DoubleLinkedList) Remove(item *DoubleListNode) error {
+	if item == nil || item.list != l {
+		return ErrNotExists
+	}
+
+	l.len--
+	l.linkNodes(item.prev, item.next)
+	item.next = nil
+	item.prev = nil
+
+	return nil
+}

--- a/lesson-5/structures/list/double_list_test.go
+++ b/lesson-5/structures/list/double_list_test.go
@@ -1,0 +1,286 @@
+package list
+
+import "testing"
+
+var (
+	testNodes []*DoubleListNode = []*DoubleListNode{
+		{Value: 1},
+		{Value: 2},
+		{Value: 3},
+	}
+	testNodeToRemove = testNodes[1]
+	testOtherNode    = &DoubleListNode{Value: 100}
+)
+
+func TestEmpty(t *testing.T) {
+	list := DoubleLinkedList{}
+
+	expectedLen := 0
+	var expectedItem *DoubleListNode
+
+	t.Run("new empty list", func(t *testing.T) {
+		if list.Len() != 0 {
+			t.Errorf("invalid len, got %d, expected %d", list.Len(), expectedLen)
+		}
+		if list.Head() != nil {
+			t.Errorf("invalid head, got %v, expected %v", list.Head(), expectedItem)
+		}
+		if list.Tail() != nil {
+			t.Errorf("invalid tail, got %v, expected %v", list.Tail(), expectedItem)
+		}
+	})
+
+	t.Run("push nil", func(t *testing.T) {
+		list.PushHead(nil)
+		list.PushTail(nil)
+
+		if list.Len() != 0 {
+			t.Errorf("invalid len, got %d, expected %d", list.Len(), expectedLen)
+		}
+		if list.Head() != nil {
+			t.Errorf("invalid head, got %v, expected %v", list.Head(), expectedItem)
+		}
+		if list.Tail() != nil {
+			t.Errorf("invalid tail, got %v, expected %v", list.Tail(), expectedItem)
+		}
+	})
+
+	t.Run("pop from empty", func(t *testing.T) {
+		head := list.PopHead()
+		tail := list.PopTail()
+
+		if head != nil {
+			t.Errorf("invalid head, got %v, expected %v", head, expectedItem)
+		}
+		if tail != nil {
+			t.Errorf("invalid tail, got %v, expected %v", tail, expectedItem)
+		}
+
+	})
+}
+
+func TestHead(t *testing.T) {
+	list := DoubleLinkedList{}
+
+	t.Run("push values", func(t *testing.T) {
+		for i, node := range testNodes {
+			list.PushHead(node)
+
+			newLen := list.Len()
+			expectedLen := i + 1
+
+			if newLen != expectedLen {
+				t.Errorf("invalid list lenght, got %d, expected %d", newLen, expectedLen)
+			}
+
+			head := list.Head()
+			if head != node {
+				t.Errorf("invalid head, got %v, expected %v", head, node)
+			}
+		}
+	})
+
+	t.Run("iterate from head", func(t *testing.T) {
+		item := list.Head()
+		for i := list.Len() - 1; i >= 0; i-- {
+			expectedItem := testNodes[i]
+
+			if item != expectedItem {
+				t.Errorf("invalid item, got %v, expedted, %v", item, expectedItem)
+			}
+
+			item = item.Prev()
+		}
+
+		// last value should be nil to stop iteration
+		if item != nil {
+			t.Errorf("invalid item, got %v, expedted, %v", item, nil)
+		}
+	})
+
+	t.Run("pop values", func(t *testing.T) {
+		for i := len(testNodes) - 1; i >= 0; i-- {
+			expedtedNode := testNodes[i]
+			expectedLen := i
+
+			node := list.PopHead()
+			newLen := list.Len()
+
+			if newLen != expectedLen {
+				t.Errorf("invalid list lenght, got %d, expected %d", newLen, expectedLen)
+			}
+
+			if node != expedtedNode {
+				t.Errorf("invalid head, got %v, expected %v", node, expedtedNode)
+			}
+		}
+
+		// we "pop" all items, expedcted empty list
+		if list.Len() != 0 {
+			t.Errorf("invalid len, got %d, expected %d", list.Len(), 0)
+		}
+		if list.Head() != nil {
+			t.Errorf("invalid head, got %v, expected %v", list.Head(), nil)
+		}
+		if list.Tail() != nil {
+			t.Errorf("invalid tail, got %v, expected %v", list.Tail(), nil)
+		}
+	})
+}
+
+func TestTail(t *testing.T) {
+	list := DoubleLinkedList{}
+
+	t.Run("push values", func(t *testing.T) {
+		for i, node := range testNodes {
+			list.PushTail(node)
+
+			newLen := list.Len()
+			expectedLen := i + 1
+
+			if newLen != expectedLen {
+				t.Errorf("invalid list lenght, got %d, expected %d", newLen, expectedLen)
+			}
+
+			tail := list.Tail()
+			if tail != node {
+				t.Errorf("invalid tail, got %v, expected %v", tail, node)
+			}
+		}
+	})
+
+	t.Run("iterate from tail", func(t *testing.T) {
+		item := list.Tail()
+		for i := len(testNodes) - 1; i >= 0; i-- {
+			expectedItem := testNodes[i]
+
+			if item != expectedItem {
+				t.Errorf("invalid item, got %v, expedted, %v", item, expectedItem)
+			}
+
+			item = item.Next()
+		}
+
+		// last value should be nil to stop iteration
+		if item != nil {
+			t.Errorf("invalid item, got %v, expedted, %v", item, nil)
+		}
+	})
+
+	t.Run("pop values", func(t *testing.T) {
+		for i := len(testNodes) - 1; i >= 0; i-- {
+			expedtedNode := testNodes[i]
+			expectedLen := i
+
+			node := list.PopTail()
+			newLen := list.Len()
+
+			if newLen != expectedLen {
+				t.Errorf("invalid list lenght, got %d, expected %d", newLen, expectedLen)
+			}
+
+			if node != expedtedNode {
+				t.Errorf("invalid head, got %v, expected %v", node, expedtedNode)
+			}
+		}
+
+		// we "pop" all items, expedcted empty list
+		if list.Len() != 0 {
+			t.Errorf("invalid len, got %d, expected %d", list.Len(), 0)
+		}
+		if list.Head() != nil {
+			t.Errorf("invalid head, got %v, expected %v", list.Head(), nil)
+		}
+		if list.Tail() != nil {
+			t.Errorf("invalid tail, got %v, expected %v", list.Tail(), nil)
+		}
+	})
+}
+
+func TestMiddle(t *testing.T) {
+	list := DoubleLinkedList{}
+	for _, node := range testNodes {
+		list.PushHead(node)
+	}
+
+	t.Run("insert values before", func(t *testing.T) {
+		for _, item := range testNodes {
+			newNode := &DoubleListNode{Value: 0}
+
+			err := list.InsertBefore(item, newNode)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if item.Prev() != newNode {
+				t.Errorf("invalid prev item, got %v, expected %v", item.Prev(), newNode)
+			}
+		}
+	})
+
+	t.Run("insert values after", func(t *testing.T) {
+		for _, item := range testNodes {
+			newNode := &DoubleListNode{Value: 0}
+
+			err := list.InsertAfter(item, newNode)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if item.Next() != newNode {
+				t.Errorf("invalid prev item, got %v, expected %v", item.Next(), newNode)
+			}
+		}
+	})
+
+	t.Run("remove values", func(t *testing.T) {
+		err := list.Remove(testNodeToRemove)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		// iterate over list to check if node actually removed
+		for i := list.Tail(); i != nil; i = i.Next() {
+			if i == testNodeToRemove {
+				t.Errorf("node has not been removed (iter from tail)")
+			}
+		}
+		for i := list.Head(); i != nil; i = i.Prev() {
+			if i == testNodeToRemove {
+				t.Errorf("node has not been removed (iter from tail)")
+			}
+		}
+	})
+}
+
+func TestMiddleWithNotExistingNode(t *testing.T) {
+	list := DoubleLinkedList{}
+	for _, node := range testNodes {
+		list.PushHead(node)
+	}
+
+	t.Run("insert values before", func(t *testing.T) {
+		newNode := &DoubleListNode{Value: 0}
+
+		err := list.InsertBefore(testOtherNode, newNode)
+		if err != ErrNotExists {
+			t.Errorf("unexpected error, got %v, expected %v", err, ErrNotExists)
+		}
+	})
+
+	t.Run("insert values after", func(t *testing.T) {
+		newNode := &DoubleListNode{Value: 0}
+
+		err := list.InsertAfter(testOtherNode, newNode)
+		if err != ErrNotExists {
+			t.Errorf("unexpected error, got %v, expected %v", err, ErrNotExists)
+		}
+	})
+
+	t.Run("remove values", func(t *testing.T) {
+		err := list.Remove(testOtherNode)
+		if err != ErrNotExists {
+			t.Errorf("unexpected error, got %v, expected %v", err, ErrNotExists)
+		}
+	})
+}

--- a/lesson-5/structures/queue.go
+++ b/lesson-5/structures/queue.go
@@ -1,0 +1,37 @@
+package structures
+
+import (
+	"errors"
+	"gb-go-architecture/lesson-5/structures/list"
+)
+
+var ErrEmptyQueue = errors.New("Queue is empty")
+
+type Queue struct {
+	queue *list.DoubleLinkedList
+}
+
+func (q *Queue) Len() int {
+	return q.queue.Len()
+}
+
+func (q *Queue) Push(value interface{}) {
+	node := &list.DoubleListNode{Value: value}
+	q.queue.PushTail(node)
+}
+
+func (q *Queue) Pop() (value interface{}, err error) {
+	node := q.queue.PopHead()
+	if node == nil {
+		return nil, ErrEmptyQueue
+	}
+
+	return node.Value, nil
+}
+
+func NewQueue() *Queue {
+	list := &list.DoubleLinkedList{}
+	return &Queue{
+		queue: list,
+	}
+}

--- a/lesson-5/structures/queue_test.go
+++ b/lesson-5/structures/queue_test.go
@@ -27,7 +27,7 @@ func TestQueue(t *testing.T) {
 		}
 	}
 
-	// stach should be empty after we "pop" all values
+	// queue should be empty after we "pop" all values
 	_, err := queue.Pop()
 	if err != ErrEmptyQueue {
 		t.Errorf("unexpected error, got %v, expected %v", err, ErrEmptyQueue)

--- a/lesson-5/structures/queue_test.go
+++ b/lesson-5/structures/queue_test.go
@@ -1,0 +1,35 @@
+package structures
+
+import (
+	"testing"
+)
+
+var testQueueValues = []int{1, 2, 3}
+
+func TestQueue(t *testing.T) {
+	queue := NewQueue()
+
+	for _, item := range testQueueValues {
+		queue.Push(item)
+	}
+
+	if queue.Len() != len(testQueueValues) {
+		t.Errorf("invalid len, got %d, expected %d", queue.Len(), len(testQueueValues))
+	}
+
+	for _, expectedItem := range testQueueValues {
+		item, err := queue.Pop()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if item != expectedItem {
+			t.Errorf("invalid item, got %v, expected %v", item, expectedItem)
+		}
+	}
+
+	// stach should be empty after we "pop" all values
+	_, err := queue.Pop()
+	if err != ErrEmptyQueue {
+		t.Errorf("unexpected error, got %v, expected %v", err, ErrEmptyQueue)
+	}
+}

--- a/lesson-5/structures/stack.go
+++ b/lesson-5/structures/stack.go
@@ -1,0 +1,37 @@
+package structures
+
+import (
+	"errors"
+	"gb-go-architecture/lesson-5/structures/list"
+)
+
+var ErrEmptyStack = errors.New("Stack is empty")
+
+type Stack struct {
+	stack *list.DoubleLinkedList
+}
+
+func (s *Stack) Len() int {
+	return s.stack.Len()
+}
+
+func (s *Stack) Push(value interface{}) {
+	node := &list.DoubleListNode{Value: value}
+	s.stack.PushHead(node)
+}
+
+func (s *Stack) Pop() (value interface{}, err error) {
+	node := s.stack.PopHead()
+	if node == nil {
+		return nil, ErrEmptyStack
+	}
+
+	return node.Value, nil
+}
+
+func NewStack() *Stack {
+	list := &list.DoubleLinkedList{}
+	return &Stack{
+		stack: list,
+	}
+}

--- a/lesson-5/structures/stack_test.go
+++ b/lesson-5/structures/stack_test.go
@@ -30,7 +30,7 @@ func TestStack(t *testing.T) {
 		}
 	}
 
-	// stach should be empty after we "pop" all values
+	// stack should be empty after we "pop" all values
 	_, err := stack.Pop()
 	if err != ErrEmptyStack {
 		t.Errorf("unexpected error, got %v, expected %v", err, ErrEmptyStack)

--- a/lesson-5/structures/stack_test.go
+++ b/lesson-5/structures/stack_test.go
@@ -1,0 +1,38 @@
+package structures
+
+import (
+	"testing"
+)
+
+var testStackValues = []int{1, 2, 3}
+
+func TestStack(t *testing.T) {
+	stack := NewStack()
+
+	for _, item := range testStackValues {
+		stack.Push(item)
+	}
+
+	if stack.Len() != len(testStackValues) {
+		t.Errorf("invalid len, got %d, expected %d", stack.Len(), len(testStackValues))
+	}
+
+	// stack returns values in reverse order
+	for i := len(testStackValues) - 1; i >= 0; i-- {
+		expectedItem := testStackValues[i]
+
+		item, err := stack.Pop()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if item != expectedItem {
+			t.Errorf("invalid item, got %v, expected %v", item, expectedItem)
+		}
+	}
+
+	// stach should be empty after we "pop" all values
+	_, err := stack.Pop()
+	if err != ErrEmptyStack {
+		t.Errorf("unexpected error, got %v, expected %v", err, ErrEmptyStack)
+	}
+}


### PR DESCRIPTION
Несколько нюансов по реализации:
1) двусвязный список
каждый элемент содержит ссылку на экземпляр списка, чтобы не изменить другой экземпляр, если пользователь ошибется с указателем в методах InsetBefore, InsertAfter, Remove.
Идею подсмотрел в реализации списка в стандартном container/list

2) LRU
* В задании не оговорено, поэтому использовал список из стандартной либы, а не свой велосипед.
* В каждом элементе кэша хранится пара ключ-значение, а не просто значение. Это нужно для того, чтобы при удалении 
самого старого элемента из очереди быстро найти его в map (без итерирования)

\+ Все структуры не расчитаны на многопоточное использование, для этого нужно добавить мьютексы.
